### PR TITLE
Add hyperlinks to project

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,9 @@
                             latency of the final model to about 50%.</li>
                     </ul>
                 </td>
+                <td>
+                    <a href="https://arxiv.org/abs/2401.15724">Regains and enchant</a>
+                </td>
             </tr>
             <tr>
                 <td class="pointer">
@@ -222,6 +225,9 @@
                         <li>A tool to run code on the cloud server that’s easy to scale.</li>
                         <li>Built using NextJS, Material UI and implemented with S.O.L.I.D principles.</li>
                     </ul>
+                </td>
+                <td>
+                    <a href="https://github.com/sudip-mondal-2002/code-runner">Code runner</a>
                 </td>
             </tr>
 


### PR DESCRIPTION
Related to #3

Add hyperlinks to the specified projects in the "Projects & Publications" section of the resume.

* Add a hyperlink for "Regains and enchant" to https://arxiv.org/abs/2401.15724.
* Add a hyperlink for "Code runner" to https://github.com/sudip-mondal-2002/code-runner.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sudip-mondal-2002/resume/issues/3?shareId=8c99b1ce-281d-4e23-a644-91a64f806d56).