### PR TITLE
Handle print event

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,18 @@
             margin: 0 0 0 20px;
             padding: 0;
         }
+
+        @media print {
+            body {
+                display: none;
+            }
+
+            .resume {
+                display: block;
+                width: 100%;
+                box-shadow: none;
+            }
+        }
     </style>
 </head>
 


### PR DESCRIPTION
Closes #5

Add print-specific CSS rules to limit printed content to the `.resume` div.

* **Print-specific CSS rules**
  - Add `@media print` rule to the existing stylesheet.
  - Set `body` to `display: none` within the `@media print` rule.
  - Set `.resume` to `display: block`, `width: 100%`, and `box-shadow: none` within the `@media print` rule.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sudip-mondal-2002/resume/issues/5?shareId=bb20714c-c44f-4e38-a1bd-e0ed9ab7fcb5).